### PR TITLE
Fix custom options overwritten by default options

### DIFF
--- a/src/components/MarkdownPreview.jsx
+++ b/src/components/MarkdownPreview.jsx
@@ -12,7 +12,6 @@ export default class MarkdownPreview extends React.Component {
     }
 
     options = {
-      ...options,
       gfm: true,
       tables: true,
       breaks: false,
@@ -27,7 +26,8 @@ export default class MarkdownPreview extends React.Component {
         } else {
           return code;
         }
-      }
+      },
+      ...options
     };
     marked.setOptions(options);
   }


### PR DESCRIPTION
Setting the default options after the `...options` spread operator, will always override any custom option.
This PR will fix that, by
* first setting the default options
* then using the spread operator to merge the given custom options.