### PR TITLE
Move react to devDependencies/peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1710,6 +1710,7 @@
       "version": "15.6.0",
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
       "integrity": "sha1-q0SEl8JlZuHilBPogyB9V8/nvtQ=",
+      "dev": true,
       "requires": {
         "fbjs": "0.8.14",
         "loose-envify": "1.3.1",
@@ -3932,6 +3933,7 @@
       "version": "15.6.1",
       "resolved": "https://registry.npmjs.org/react/-/react-15.6.1.tgz",
       "integrity": "sha1-uqhDTsZ4C96ZfNw4C3nNM7ljk98=",
+      "dev": true,
       "requires": {
         "create-react-class": "15.6.0",
         "fbjs": "0.8.14",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "mocha": "3.0.1",
     "nodemon": "1.10.1",
     "react-addons-test-utils": "^15.2.1",
+    "react": "^15.2.1",
     "react-dom": "^15.2.1"
   },
   "dependencies": {
@@ -41,7 +42,9 @@
     "enzyme": "^2.4.1",
     "highlight.js": "^9.3.0",
     "marked": "^0.3.5",
-    "prop-types": "^15.5.10",
+    "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
     "react": "^15.2.1"
   }
 }


### PR DESCRIPTION
Having react as a dependency is causing two different versions of react to be installed in my app. Common practice for react libraries is to list is as a peer dependency instead.